### PR TITLE
ストック機能のUIを調整した

### DIFF
--- a/app/assets/stylesheets/logs.scss
+++ b/app/assets/stylesheets/logs.scss
@@ -4,7 +4,6 @@
 
 $site-main-color: #80c683;
 
-// Devise style
 .log-input-field,
 .log-input-field-small,
 .log-check-field {
@@ -20,7 +19,19 @@ $site-main-color: #80c683;
     width: 85%;
     &-small {
       text-align: right;
-      width: 65%;
+      width: 63%;
+    }
+    &-lang {
+      line-height: 1.5;
+      text-align: center;
+      width: 58%;
+      margin: 30px auto 0;
+      input {
+        margin-right: 5px;
+      }
+      label {
+        margin-right: 20px;
+      }
     }
   }
   &-large {
@@ -33,7 +44,12 @@ $site-main-color: #80c683;
     width: 200px;
   }
 }
-// end Devise style
+
+.label-center {
+  display: block;
+  text-align: center;
+  margin-bottom: 10px;
+}
 
 .log-index-head {
   background-color: $site-main-color;

--- a/app/assets/stylesheets/shared.scss
+++ b/app/assets/stylesheets/shared.scss
@@ -34,7 +34,7 @@ form {
   padding: 30px 0 50px;
   &-inner {
     @include inner-base;
-    margin: 0 auto;
+    margin: 0 auto 30px;
     min-height: calc(100vh - 50px - 264px - 164px);
   }
   .app-bottom-inner {
@@ -47,8 +47,12 @@ form {
     justify-content: space-around;
     margin: 20px auto;
     width: 65%;
+    form {
+      margin: 0 auto;
+    }
   }
 }
+
 
 .bottom-profile {
   &__upper {
@@ -106,6 +110,7 @@ form {
 @mixin btn {
   border: 2px solid $site-dark-color;
   border-radius: 20px;
+  height: fit-content;
   margin: 20px auto;
   padding: 1.2vh 2.5vw;
   text-decoration: none;
@@ -130,6 +135,17 @@ form {
   &:hover {
     @include btn-fill;
     transition-duration: 0.25s;
+    .stock-count__number {
+      @include btn-empty();
+      padding: 3px 5px;
+      border-radius: 20px;
+      transition-duration: 0.25s;
+    }
+  }
+  .stock-count__number {
+    @include btn-fill;
+    padding: 3px 5px;
+    border-radius: 20px;
   }
 }
 
@@ -139,6 +155,17 @@ form {
   &:hover {
     @include btn-empty;
     transition-duration: 0.25s;
+    .stock-count__number {
+      @include btn-fill();
+      padding: 3px 5px;
+      border-radius: 20px;
+      transition-duration: 0.25s;
+    }
+  }
+  .stock-count__number {
+    @include btn-empty();
+    padding: 3px 5px;
+    border-radius: 20px;
   }
 }
 
@@ -200,50 +227,10 @@ form {
     height: 80%;
     max-width: 800px;
     margin: 0 auto;
-    .footer-left  {
-      width: 60%;
-      .footer-site-name {
-        font-size: 2rem;
-        font-weight: bold;
-        margin: 0 0 20px;
-      }
-    }
-    .footer-right {
-      width: 40%;
-    }
     a,
     p {
       color: white;
       text-decoration: none;
-    }
-    .footer-left {
-      margin-left: 5%;
-      p {
-        margin: 10px 0;
-      }
-      .footer-sns-area {
-        display: flex;
-        img {
-          margin-right: 20px;
-        }
-      }
-    }
-    .footer-right {
-      display: flex;
-      &-start,
-      &-end {
-        width: 50%;
-        display: flex;
-        flex-direction: column;
-        p:first-child {
-          margin: 0;
-          font-weight: bold;
-        }
-        a {
-          color: rgb(159, 159, 159);
-          margin-top: 1em;
-        }
-      }
     }
   }
   .footer-bottom {
@@ -262,6 +249,44 @@ form {
       width: 70%;
     }
   }
+  
+.footer-left  {
+  width: 60%;
+  margin-left: 5%;
+  p {
+    margin: 10px 0;
+  }
+  .footer-sns-area {
+    display: flex;
+    img {
+      margin-right: 20px;
+    }
+  }
+  .footer-site-name {
+    font-size: 2rem;
+    font-weight: bold;
+    margin: 0 0 20px;
+  }
+}
+.footer-right {
+  width: 40%;
+  display: flex;
+  &-start,
+  &-end {
+    width: 50%;
+    display: flex;
+    flex-direction: column;
+    p:first-child {
+      margin: 0;
+      font-weight: bold;
+    }
+    a {
+      color: rgb(159, 159, 159);
+      margin-top: 1em;
+    }
+  }
+}
+  
 }
 // end footer style
 

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -2,4 +2,11 @@ module UsersHelper
   def display_languages(languages)
     languages.map(&:name).join(', ')
   end
+  def display_release(release)
+    if release == true
+      "公開"
+    else
+      "非公開"
+    end
+  end
 end

--- a/app/models/log.rb
+++ b/app/models/log.rb
@@ -8,6 +8,5 @@ class Log < ApplicationRecord
   with_options presence: { message: 'が入力されていません。'} do 
     validates :title
     validates :error
-    validates :release
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -14,4 +14,13 @@ class User < ApplicationRecord
   def already_stocked?(log)
     self.stocks.exists?(log_id: log.id)
   end
+
+  def stock_ids
+    Stock.where(user_id: self.id).pluck(:log_id)
+  end
+
+  def my_stocks
+    Log.where(id: self.stock_ids).order(created_at: :desc)
+  end
+
 end

--- a/app/views/logs/_form.html.erb
+++ b/app/views/logs/_form.html.erb
@@ -15,10 +15,12 @@
   <%= f.label :language, "開発言語", class: "label-center" %>
   <%= f.collection_check_boxes :language_ids, Language.all, :id, :name, { class: "log-input-small", id: "language" } %>
   </div>
-  <div class="log-input-field-small">
-    <%= f.label :release, "公開状態" %>
-    <%= f.radio_button :release, "公開", class: "log-input-radio", id: "release", checked: "checked" %>公開
-    <%= f.radio_button :release, "非公開", class: "log-input-radio", id: "release" %>非公開
+  <div class="log-input-field-lang">
+    <%= f.label :release, "公開状態", class: "label-center" %>
+    <%= f.radio_button :release, true, class: "log-input-radio", id: "release" %>
+    <%= f.label :release, "公開", value: true %>
+    <%= f.radio_button :release, false, class: "log-input-radio", id: "release" %>
+    <%= f.label :release, "非公開", value: false %>
   </div>
   <div class="inner-bottom-btn-wrap">
     <%= f.submit "保存する", class: "btn-default" %>

--- a/app/views/logs/_form.html.erb
+++ b/app/views/logs/_form.html.erb
@@ -11,9 +11,9 @@
     <%= f.label :solution, "解決方法" %>
     <%= f.text_area :solution, class: "log-input-large" ,id: "solution" %>
   </div>
-  <div class="log-input-field-small">
-    <%= f.label :language, "言語" %>
-    <%= f.collection_check_boxes :language_ids, Language.all, :id, :name, { prompt: "言語を選択してください" }, { class: "log-input-small", id: "language" } %>
+  <div class="log-input-field-lang">
+  <%= f.label :language, "開発言語", class: "label-center" %>
+  <%= f.collection_check_boxes :language_ids, Language.all, :id, :name, { class: "log-input-small", id: "language" } %>
   </div>
   <div class="log-input-field-small">
     <%= f.label :release, "公開状態" %>

--- a/app/views/logs/index.html.erb
+++ b/app/views/logs/index.html.erb
@@ -1,5 +1,5 @@
 <section class="app-body-inner">
-  <h1>みんなの最新ノート</h1>
+  <h1>新着ノート</h1>
   <table class="log-table" width="90%">
     <thead>
       <tr class="log-index-head">

--- a/app/views/logs/show.html.erb
+++ b/app/views/logs/show.html.erb
@@ -22,14 +22,17 @@
 
   <div class="inner-bottom-btn-wrap">
     <% if user_signed_in? %>
-      <%= "ストックされた数:#{@log.stocks.count}" %>
       <% if current_user.id == @log.user.id %>
         <%= link_to("ログを編集する", "/users/#{current_user.id}/logs/#{@log.id}/edit", {class: "btn-filled"}) %>
       <% else %>
         <% if current_user.already_stocked?(@log) %>
-          <%= button_to 'ストックを取り消す', user_log_stock_path(current_user, @log), method: :delete %>
+          <%= button_to user_log_stock_path(current_user, @log), method: :delete, class:"btn-filled" do %>
+            <p>ストックを取り消す <span class="stock-count__number"><%= @log.stocks.count %></span></p>
+          <% end %>
         <% else %>
-          <%= button_to 'ストック', user_log_stocks_path(current_user, @log) %>
+          <%= button_to user_log_stocks_path(current_user, @log), class:"btn-default" do %>
+            <p>ストックする <span class="stock-count__number"><%= @log.stocks.count %></span></p>
+          <% end %>
         <% end %>
       <% end %>
     <% end %>
@@ -52,7 +55,7 @@
   </div>
   <div class="bottom-profile__lower">
     <div class="profile-btn__container">
-      <%= link_to "フォローする", "#", class: "btn-filled" if current_user.id != @log.user.id %>
+      <%= link_to "フォローする", "#", class: "btn-filled" if user_signed_in? && (current_user.id != @log.user.id) %>
       <%= link_to "プロフィールへ", [@log.user], class: "btn-default" %>
     </div>
   </div>

--- a/app/views/users/_table.html.erb
+++ b/app/views/users/_table.html.erb
@@ -1,0 +1,24 @@
+<table class="log-table" width="90%">
+  <thead>
+    <tr class="log-index-head">
+      <th class="log-index-small-col">更新日</th>
+      <th class="log-index-big-col">タイトル</th>
+      <th class="log-index-small-col">言語</th>
+      <% if stock == "false" %>
+        <th class="log-index-small-col">公開状態</th>
+      <% end %>
+    </tr>
+  </thead> 
+  <tbody>
+    <% logs.each do |log| %>
+    <tr class="log-index-body">
+      <td class="align-center"><%= l log.updated_at, format: :shortest %></td>
+      <td><%= link_to log.title, "#{log.user_id}/logs/#{log.id}" %></td>
+      <td class="align-center"><%= display_languages(log.languages) %></td>
+      <% if stock == "false" %>
+        <td class="align-center"><%= display_release(log.release) %></td>
+      <% end %>
+    </tr>
+    <% end %>
+  </tbody>
+</table>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,37 +1,40 @@
 <section class="app-body-inner">
-  <h1><%= @user.name %>のマイページ</h1>
-  <table class="log-table" width="90%">
-    <thead>
-      <tr class="log-index-head">
-        <th class="log-index-small-col">更新日</th>
-        <th class="log-index-big-col">タイトル</th>
-        <th class="log-index-small-col">言語</th>
-        <th class="log-index-small-col">公開</th>
-      </tr>
-    </thead> 
-    <tbody>
-      <% @logs.each do |log| %>
-      <tr class="log-index-body">
-        <td class="align-center"><%= l log.updated_at, format: :shortest %></td>
-        <td><%= link_to log.title, "#{log.user_id}/logs/#{log.id}" %></td>
-        <td class="align-center"><%= display_languages(log.languages) %></td>
-        <td class="align-center"><%= log.release %></td>
-      </tr>
-      <% end %>
-    </tbody>
-  </table>
+  <h1><%= @user.name %>のノート</h1>
+  <%= render "table", logs: @logs, stock: "false" %>
   <div class="inner-bottom-btn-wrap">
-    <% if user_signed_in? && (current_user.id == @user.id) %>
-      <div>
-        <% current_user.stocks.each do |stock| %>
-          <% log = stock.log %>
-          <p><%= link_to("#{log.title}", user_log_path(log.user, log)) %></p>
-        <% end %>
-      </div>
-      <%= link_to("プロフィール編集", edit_user_registration_path,{ method: :get, class: "btn-filled" }) %>
-      <%= link_to("ログアウト", '/users/sign_out',{ method: :delete, class: "btn-default" }) %>
-    <% else %>
-      <%= link_to("フォローする", '#',{ class: "btn-filled" }) %>
-    <% end %>
   </div>
 </section>
+
+<% if user_signed_in? && (current_user.id == @user.id) %>
+  <section class="app-body-inner">
+    <h1>最近のストック</h1>
+    <%- mystocks = @user.my_stocks %>
+    <%= render "table", logs: mystocks, stock: "true" %>
+  </section>
+<% end %>
+
+<div class="app-bottom-inner">
+  <div class="bottom-profile__upper">
+    <div class="profile-img__container">
+      <%= image_tag('site-bg.png') %>
+    </div>
+    <div class="profile-introduce__container">
+      <div class="profile-introduce__name">
+        <h2><%= @user.name %></h2>
+      </div>
+      <div class="profile-introduce__word">
+        <p>これはダミーテキストです。これはダミーテキストです。これはダミーテキストです。これはダミーテキストです。これはダミーテキストです。これはダミーテキストです。これはダミーテキストです。これはダミーテキストです。</p>
+      </div>
+    </div>
+  </div>
+  <div class="bottom-profile__lower">
+    <div class="profile-btn__container">
+      <% if user_signed_in? && (current_user.id == @user.id) %>
+        <%= link_to("プロフィール編集", edit_user_registration_path,{ method: :get, class: "btn-filled" }) %>
+        <%= link_to("ログアウト", '/users/sign_out',{ method: :delete, class: "btn-default" }) %>
+      <% elsif user_signed_in? && (current_user.id != @user.id) %>
+        <%= link_to("フォローする", '#',{ class: "btn-filled" }) %>
+      <% end %>
+    </div>
+  </div>
+</div>


### PR DESCRIPTION
## PRの内容
- ストックボタンをスタイリングした
- マイページにストック一覧を表示できるようにした
- ログ機能に関する軽微な不具合を修正した
- ログ作成ビューのスタイル崩れを修正した

## 動作確認方法
1. `git fetch origin pull/34/head:feature-create-stock-ui`
2. `git checkout feature-create-stock-ui`
3. `rails s`
4. 各動作を確認

## 画面プレビュー

1. ストックボタン（未ストック）

<img width="632" alt="dba8b3ce38786010d907582b5e774c27" src="https://user-images.githubusercontent.com/68951522/115988868-7d709480-a5f6-11eb-94bd-2c4044c3f3cc.png">

2. ストックボタン（既ストック）

<img width="636" alt="147ea00bba53afb674399272fc5432c7" src="https://user-images.githubusercontent.com/68951522/115988877-806b8500-a5f6-11eb-9700-0cfce7ce1df3.png">

3. マイページのストック一覧

<img width="814" alt="48b1916ebf19505f99188cfa174e4449" src="https://user-images.githubusercontent.com/68951522/115988880-82cddf00-a5f6-11eb-8dad-b57634e57ba0.png">

4. ログ作成画面の言語選択部分

<img width="524" alt="21e8fb8a6e4c38422121ae7c1b23d2ed" src="https://user-images.githubusercontent.com/68951522/115988885-86616600-a5f6-11eb-8433-a0c6312db3ad.png">

