### PR TITLE
日本語に対応した

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -33,6 +33,7 @@ end
 
 gem 'react-rails'
 gem 'devise'
+gem 'devise-i18n'
 gem 'rails-i18n'
 
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -90,6 +90,8 @@ GEM
       railties (>= 4.1.0)
       responders
       warden (~> 1.2.3)
+    devise-i18n (1.9.3)
+      devise (>= 4.7.1)
     erubi (1.10.0)
     execjs (2.7.0)
     ffi (1.15.0)
@@ -233,6 +235,7 @@ DEPENDENCIES
   byebug
   capybara (>= 3.26)
   devise
+  devise-i18n
   jbuilder (~> 2.7)
   listen (~> 3.3)
   mysql2 (~> 0.5)

--- a/app/assets/stylesheets/shared.scss
+++ b/app/assets/stylesheets/shared.scss
@@ -3,6 +3,8 @@ $site-dark-color: #509556;
 $site-light-color: #b1f9b3;
 $site-font-color: black;
 $site-footer-bg-color: rgb(82, 82, 82);
+$site-error-border-color: rgb(182, 0, 0); 
+$site-error-bg-color: rgb(255, 187, 187); 
 $header-height: 50px;
 
 // add reset css
@@ -46,7 +48,7 @@ form {
     display: flex;
     justify-content: space-around;
     margin: 20px auto;
-    width: 65%;
+    width: 75%;
     form {
       margin: 0 auto;
     }
@@ -291,6 +293,22 @@ form {
 // end footer style
 
 // Devise style
+#error_explanation {
+  background-color: $site-error-bg-color;
+  border: 5px solid $site-error-border-color;
+  border-radius: 20px;
+  margin: 0 auto;
+  width: 80%;
+  h2 {
+    font-size: 1rem;
+    padding: 10px;
+  }
+  li {
+    list-style: none;
+    line-height: 1.5;
+  }
+}
+
 .user-input-field,
 .user-check-field {
   margin-top: 30px;
@@ -318,8 +336,8 @@ form {
 
 .error-message {
   &__container {
-    background-color: $site-light-color;
-    border: 5px solid $site-main-color;
+    background-color: $site-error-bg-color;
+    border: 5px solid $site-error-border-color;
     border-radius: 20px;
     margin: 0 auto;
     width: 80%;
@@ -332,7 +350,7 @@ form {
 
 .field_with_errors,
 .field_with_errors label {
-  color: $site-dark-color;
+  color: $site-error-border-color;
   display: inline;
 }
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -8,7 +8,6 @@ class User < ApplicationRecord
   with_options presence: { message: 'が入力されていません。'} do 
     validates :name
     validates :kana, format: { with: /\A[ァ-ヶー－]+\z/, message: 'は全角カタカナのみ登録できます。' }
-    validates :email
   end
 
   def already_stocked?(log)

--- a/app/views/devise/shared/_error_messages.html.erb
+++ b/app/views/devise/shared/_error_messages.html.erb
@@ -8,7 +8,7 @@
     </h2>
     <ul>
       <% resource.errors.full_messages.each do |message| %>
-        <li><%= message %></li>
+        <li><i class="fas fa-pen"></i> <%= message %></li>
       <% end %>
     </ul>
   </div>

--- a/config/locales/devise.ja.yml
+++ b/config/locales/devise.ja.yml
@@ -1,0 +1,85 @@
+ja:
+  activerecord:
+    errors:
+      models:
+        user:
+          attributes:
+            email:
+              taken: "は既に使用されています。"
+              blank: "が入力されていません。"
+              too_short: "は%{count}文字以上に設定して下さい。"
+              too_long: "は%{count}文字以下に設定して下さい。"
+              invalid: "は有効でありません。"
+            password:
+              taken: "は既に使用されています。"
+              blank: "が入力されていません。"
+              too_short: "は%{count}文字以上に設定して下さい。"
+              too_long: "は%{count}文字以下に設定して下さい。"
+              invalid: "は有効でありません。"
+              confirmation: "が内容とあっていません。"
+    attributes:
+      user:
+        current_password: "現在のパスワード"
+        name: 名前
+        email: "メールアドレス"
+        password: "パスワード"
+        password_confirmation: "確認用パスワード"
+        remember_me: "次回から自動的にログイン"
+    models:
+      user: "ユーザ"
+  devise:
+    confirmations:
+      new:
+        resend_confirmation_instructions: "アカウント確認メール再送"
+    mailer:
+      confirmation_instructions:
+        action: "アカウント確認"
+        greeting: "ようこそ、%{recipient}さん!"
+        instruction: "次のリンクでメールアドレスの確認が完了します:"
+      reset_password_instructions:
+        action: "パスワード変更"
+        greeting: "こんにちは、%{recipient}さん!"
+        instruction: "誰かがパスワードの再設定を希望しました。次のリンクでパスワードの再設定が出来ます。"
+        instruction_2: "あなたが希望したのではないのなら、このメールは無視してください。"
+        instruction_3: "上のリンクにアクセスして新しいパスワードを設定するまで、パスワードは変更されません。"
+      unlock_instructions:
+        action: "アカウントのロック解除"
+        greeting: "こんにちは、%{recipient}さん!"
+        instruction: "アカウントのロックを解除するには下のリンクをクリックしてください。"
+        message: "ログイン失敗が繰り返されたため、アカウントはロックされています。"
+    passwords:
+      edit:
+        change_my_password: "パスワードを変更する"
+        change_your_password: "パスワードを変更"
+        confirm_new_password: "確認用新しいパスワード"
+        new_password: "新しいパスワード"
+      new:
+        forgot_your_password: "パスワードを忘れましたか?"
+        send_me_reset_password_instructions: "パスワードの再設定方法を送信する"
+    registrations:
+      edit:
+        are_you_sure: "本当に良いですか?"
+        cancel_my_account: "アカウント削除"
+        currently_waiting_confirmation_for_email: "%{email} の確認待ち"
+        leave_blank_if_you_don_t_want_to_change_it: "空欄のままなら変更しません"
+        title: "%{resource}編集"
+        unhappy: "気に入りません"
+        update: "更新"
+        we_need_your_current_password_to_confirm_your_changes: "変更を反映するには現在のパスワードを入力してください"
+      new:
+        sign_up: "アカウント登録"
+    sessions:
+      new:
+        sign_in: "ログイン"
+    shared:
+      links:
+        back: "戻る"
+        didn_t_receive_confirmation_instructions: "アカウント確認のメールを受け取っていませんか?"
+        didn_t_receive_unlock_instructions: "アカウントの凍結解除方法のメールを受け取っていませんか?"
+        forgot_your_password: "パスワードを忘れましたか?"
+        sign_in: "ログイン"
+        sign_in_with_provider: "%{provider}でログイン"
+        sign_up: "アカウント登録"
+    unlocks:
+      new:
+        resend_unlock_instructions: "アカウントの凍結解除方法を再送する"

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -6,6 +6,39 @@ ja:
         restrict_dependent_destroy:
           has_one: "%{record}が存在しているので削除できません"
           has_many: "%{record}が存在しているので削除できません"
+    models:
+      user: ユーザー 
+      log: ログ
+      stock: ストック
+    attributes:
+      user:
+        id: ID
+        name: 名前
+        kana: 名前（カタカナ）
+        picture: 画像
+        introduce: 自己紹介
+        email: メールアドレス
+        password: パスワード
+        password_confirmation: パスワード（確認）
+      log:
+        id: ID
+        user_id: ユーザーID
+        title: タイトル
+        error: エラーの内容
+        solution: 解決方法
+        language: 開発言語
+        release: 公開状態
+      language: 
+        id: ID
+        name: 言語名
+      log_language:
+        id: ID
+        log_id: ログID
+        language_id: 言語ID
+      stock:
+        id: ID
+        log_id: ログID
+        user_id: ユーザーID
   date:
     abbr_day_names:
     - 日


### PR DESCRIPTION
## PRの内容
- エラーメッセージを日本語化した
- エラーメッセージのスタイルを再調整した
- deviseのエラーメッセージ日本語化に当たって、devise-i18n(gem)を導入した
- エラーメッセージの配色を変更した（直感的にエラーだと認識できるようにするため）

Issue： #40 

## 画面プレビュー

![67bf4998eded668c24b2f89e25811ae2](https://user-images.githubusercontent.com/68951522/116321308-b37b6780-a7f4-11eb-9f59-b911e2174be1.png)

*なぜかメールアドレスに関するメッセージが2つある。後ほど別で調査予定。