### PR TITLE
ログ検索機能を追加

### DIFF
--- a/app/controllers/logs_controller.rb
+++ b/app/controllers/logs_controller.rb
@@ -2,7 +2,7 @@ class LogsController < ApplicationController
   before_action :find_log, only: [:show, :edit, :update]
 
   def index
-    @logs = Log.all.includes(:user).order('updated_at DESC').first(10)
+    @logs = Log.all.includes(:user, :languages).order('updated_at DESC').first(10)
   end
 
   def new

--- a/app/controllers/logs_controller.rb
+++ b/app/controllers/logs_controller.rb
@@ -38,6 +38,10 @@ class LogsController < ApplicationController
     redirect_to user_path(current_user)
   end
 
+  def search
+    @logs = Log.search(params[:keyword])
+  end
+
   private
 
   def log_params

--- a/app/models/log.rb
+++ b/app/models/log.rb
@@ -12,9 +12,9 @@ class Log < ApplicationRecord
 
   def self.search(keyword)
     logs = if keyword.empty?
-             Log.all
+             Log.all.includes(:user, :languages).order('updated_at DESC').first(10)
            else
-             Log.where('title LIKE(?)', "%#{keyword}%")
+             Log.where('title LIKE(?)', "%#{keyword}%").includes(:user, :languages).order('updated_at DESC')
            end
   end
 end

--- a/app/models/log.rb
+++ b/app/models/log.rb
@@ -9,4 +9,12 @@ class Log < ApplicationRecord
     validates :title
     validates :error
   end
+
+  def self.search(keyword)
+    logs = if keyword.empty?
+             Log.all
+           else
+             Log.where('title LIKE(?)', "%#{keyword}%")
+           end
+  end
 end

--- a/app/views/logs/search.html.erb
+++ b/app/views/logs/search.html.erb
@@ -1,0 +1,23 @@
+<section class="app-body-inner">
+  <h1>検索結果</h1>
+  <table class="log-table" width="90%">
+    <thead>
+      <tr class="log-index-head">
+        <th class="log-index-small-col">更新日</th>
+        <th class="log-index-big-col">タイトル</th>
+        <th class="log-index-small-col">言語</th>
+        <th class="log-index-small-col">ユーザー</th>
+      </tr>
+    </thead> 
+    <tbody>
+      <% @logs.each do |log| %>
+      <tr class="log-index-body">
+        <td class="align-center"><%= l log.updated_at, format: :shortest %></td>
+        <td><%= link_to log.title, user_log_path(log.user, log) %></td>
+        <td class="align-center"><%= display_languages(log.languages) %></td>
+        <td class="align-center"><%= log.user.name %></td>
+      </tr>
+      <% end %>
+    </tbody>
+  </table>
+</section>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -4,6 +4,15 @@
     <h1><%= link_to "Error Note", root_path %></h1>
   </div>
   <div class="header-center flex-3">
+<% if user_signed_in? %>
+        <%= form_with(url: search_user_logs_path(current_user), local: true, method: :get) do |form| %>
+          <span class="fa-stack">
+            <%= form.text_field :keyword, placeholder:"キーワードを入力", class: "fa-lg fa-stack-2x" ,style:"width: 25vw; padding: 5px 5px 5px 32px; font-size: 1em; text-align: left;" %>
+            <i class="fas fa-search fa-lg fa-stack-1x" style="font-size: 1em;"></i>
+          </span>
+          <%= form.submit "検索", type: "hidden" %>
+        <% end %>
+    <% end %>
   </div>
   <div class="header-right flex-3">
     <div class="header-btn-wrap">

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -4,14 +4,14 @@
     <h1><%= link_to "Error Note", root_path %></h1>
   </div>
   <div class="header-center flex-3">
-<% if user_signed_in? %>
-        <%= form_with(url: search_user_logs_path(current_user), local: true, method: :get) do |form| %>
-          <span class="fa-stack">
-            <%= form.text_field :keyword, placeholder:"キーワードを入力", class: "fa-lg fa-stack-2x" ,style:"width: 25vw; padding: 5px 5px 5px 32px; font-size: 1em; text-align: left;" %>
-            <i class="fas fa-search fa-lg fa-stack-1x" style="font-size: 1em;"></i>
-          </span>
-          <%= form.submit "検索", type: "hidden" %>
-        <% end %>
+    <% if user_signed_in? %>
+      <%= form_with(url: search_user_logs_path(current_user), local: true, method: :get) do |form| %>
+        <span class="fa-stack">
+          <%= form.text_field :keyword, placeholder:"キーワードを入力", class: "fa-lg fa-stack-2x" ,style:"width: 25vw; padding: 5px 5px 5px 32px; font-size: 1em; text-align: left;" %>
+          <i class="fas fa-search fa-lg fa-stack-1x" style="font-size: 1em;"></i>
+        </span>
+        <%= form.submit "検索", type: "hidden" %>
+      <% end %>
     <% end %>
   </div>
   <div class="header-right flex-3">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,6 +5,9 @@ Rails.application.routes.draw do
   root 'logs#index'
   resources :users, only: [:index, :show] do
     resources :logs do
+      collection do
+        get 'search'
+      end
       resources :stocks, only: [:create, :destroy]
     end
   end


### PR DESCRIPTION
# やったこと
- ログをタイトルで部分一致検索できるようにしました。
- 検索窓をヘッダーの`class="header-center flex-3"`に設置しました。
- CSSを直書き、font awesomeを使ってます。
- また、submitボタン自体はhiddenで、エンターで検索する感じです。(ユーザービリティが良くねえ！などあったら修正します🙇)

## やってしまったこと
- 検索窓がヘッダーからはみ出る。
申し訳ないですが、UIを乱してしまいました🙇
色々試してみたんだけど、ちょっと分からなかった。
直書きしてるCSSは全然編集してもらって大丈夫ですので、お手隙の際に手直しを入れていただけるとありがたいです🙏

### root_path
<img width="1296" alt="ErrorNote" src="https://user-images.githubusercontent.com/56726628/116514210-af8b3a80-a905-11eb-84f7-ab49be4fdeb4.png">

### 検索結果
<img width="1303" alt="ErrorNote" src="https://user-images.githubusercontent.com/56726628/116514378-e5c8ba00-a905-11eb-8c64-4828ef38bfef.png">
