### PR TITLE
プログラミング言語一覧の初期データを投入

### DIFF
--- a/app/controllers/logs_controller.rb
+++ b/app/controllers/logs_controller.rb
@@ -40,7 +40,7 @@ class LogsController < ApplicationController
   end
 
   def search
-    @logs = Log.search(params[:keyword])
+    @logs = Log.search(params[:keyword]).order('updated_at DESC').page(params[:page]).per(10)
   end
 
   private

--- a/db/migrate/20210504125630_define_languages.rb
+++ b/db/migrate/20210504125630_define_languages.rb
@@ -1,0 +1,11 @@
+class DefineLanguages < ActiveRecord::Migration[6.1]
+  def change
+    Language.delete_all
+    ActiveRecord::Base.connection.execute('alter table languages auto_increment = 1;')
+
+    languages = ["C", "C#", "C++", "COBOL", "Go", "Java", "JavaScript", "Kotlin", "Kuin", "LISP", "MATLAB", "Node.js", "PHP", "Perl", "Python", "R", "Ruby", "Rust", "Scala", "Swift", "TypeScript", "VisualBasic.NET"]
+    languages.each do |language|
+      Language.create(name: language)
+    end
+  end
+end

--- a/db/migrate/20210504125630_define_languages.rb
+++ b/db/migrate/20210504125630_define_languages.rb
@@ -1,6 +1,6 @@
 class DefineLanguages < ActiveRecord::Migration[6.1]
   def change
-    Language.delete_all
+    Language.destroy_all
     ActiveRecord::Base.connection.execute('alter table languages auto_increment = 1;')
 
     languages = ["C", "C#", "C++", "COBOL", "Go", "Java", "JavaScript", "Kotlin", "Kuin", "LISP", "MATLAB", "Node.js", "PHP", "Perl", "Python", "R", "Ruby", "Rust", "Scala", "Swift", "TypeScript", "VisualBasic.NET"]

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_04_30_113609) do
+ActiveRecord::Schema.define(version: 2021_05_04_125630) do
 
   create_table "languages", charset: "utf8", force: :cascade do |t|
     t.string "name", null: false


### PR DESCRIPTION
# やったこと
先日のMTGで決めた内容で滞りなく実装できました。
- マイグレーションにて初期データ投入
  - 配列`languages`は.sortで並び替えてあります。

## 確認したこと
- db:migrate:redo, reset共に正常動作すること
- ログを正常にCRUDできること
- ごめん、言語選択のview崩しました🙇

### root画面(変更無し)
<img width="688" alt="ErrorNote" src="https://user-images.githubusercontent.com/56726628/117009461-bb706580-ad26-11eb-88e7-9a56754713e5.png">

### ログ作成画面
<img width="692" alt="ErrorNote" src="https://user-images.githubusercontent.com/56726628/117009625-eb1f6d80-ad26-11eb-9081-872ad98e568b.png">

### Languageテーブル
<img width="770" alt="_MySQL_5_6_50__localhost_error_note_sample_development_languages" src="https://user-images.githubusercontent.com/56726628/117009890-2cb01880-ad27-11eb-998b-c7f31e03bede.png">

