### PR TITLE
rubocopの警告基準W以上を表示できるrakeタスクを定義

### DIFF
--- a/lib/tasks/rubocop.rake
+++ b/lib/tasks/rubocop.rake
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+task rubocop: :environment do
+  sh %(rubocop --fail-level W --display-only-fail-level-offenses)
+
+  puts "Want to run 'rubocop -A'? [Y/n]"
+  input = $stdin.gets.chomp
+  if input.empty? || input.match?(/[Yy]/)
+    sh %(rubocop -A)
+  end
+end


### PR DESCRIPTION
issue #66 

# やったこと
- `rubocop --fail-level W --display-only-fail-level-offenses`を`rake rubocop`で実行できるようタスクを定義
- その後`rubocop -A`を実行するか選択できる(そのままエンターか`Y`か`y`で実行)

## なぜやったか
- 元のコマンドが長かったから
- rakeタスクの作り方知りたかったから

### 余談
rakeタスクを実行している間に、標準入力をさせるやり方に手こずった。
`gets`でいけるっしょと思っていたがだめだった。
`STDIN.gets`を使うとできた。サンキューStack Overflow

FYI:
- [ruby on rails \- How do I use "gets" on a rake task? \- Stack Overflow](https://stackoverflow.com/questions/576799/how-do-i-use-gets-on-a-rake-task)
- [$stdin \(Ruby 3\.0\.0 リファレンスマニュアル\)](https://docs.ruby-lang.org/ja/latest/method/Kernel/v/stdin.html)