### PR TITLE
ログ詳細画面のスタイルを見直した

### DIFF
--- a/app/assets/stylesheets/logs.scss
+++ b/app/assets/stylesheets/logs.scss
@@ -131,23 +131,34 @@
   }
 }
 
-.log-table {
-  border: 1px solid silver;
-  border-collapse: collapse;
-  margin: 0 auto 30px;
-  .log-index-small-col {
-    width: 15%;
+.log-detail {
+  &__langs {
+    display: flex;
+    justify-content: flex-end;
+    margin: 10px 15px 15px 0;
+    p {
+      margin-right: 5px;
+    }
   }
-  td,th {
-    border: 1px solid silver;
-    line-height: 1.5;
-    padding: 5px;
+  &__content {
+    background-color: #f0f0f0;
+    margin: 10px auto 20px;
+    padding: 20px 40px;
+    width: 85%;
+    line-height: 1.4;
+    &-title{
+      font-weight: bold;
+      margin-bottom: 10px;
+    }
+    &-nil {
+      color: silver;
+    }
   }
-  .log-show-th {
-    width: 30%;
+  .errors {
+    background-color: #fff5f5;
   }
-  tr {
-    height: 50px;
+  .solutions {
+    background-color: #f6fff4;
   }
 }
 
@@ -161,6 +172,13 @@
   margin: 0 20px 20px 0;
   text-align: right;
 }
+
+.no-content-message {
+  color: silver;
+  margin-top: 40px;
+  text-align: center;
+}
+
 // ---------------- //
 
 // pagination style //

--- a/app/assets/stylesheets/shared.scss
+++ b/app/assets/stylesheets/shared.scss
@@ -43,7 +43,7 @@ form {
   &-inner {
     @include inner-base;
     margin: 0 auto 30px;
-    min-height: calc(100vh - 50px - 264px - 164px);
+    min-height: 200px;
   }
   .app-bottom-inner {
     @include inner-base;

--- a/app/views/logs/search.html.erb
+++ b/app/views/logs/search.html.erb
@@ -1,4 +1,8 @@
 <section class="app-body-inner">
   <h1>検索結果</h1>
-  <%= render "table", logs: @logs, stock: "true" %>
+  <% if @logs.count == 0 %>
+    <p class="no-content-message">キーワードと一致するノートはありませんでした。</p>
+  <% else %>
+    <%= render "table", logs: @logs, stock: "true" %>
+  <% end %>
 </section>

--- a/app/views/logs/show.html.erb
+++ b/app/views/logs/show.html.erb
@@ -1,24 +1,27 @@
 <section class="app-body-inner">
-  <h1><%= @log.title %></h1>
-  <div class="log-updated-at">
-    <p>最終更新日：<%= l @log.updated_at, format: :default %></p>
+  <div class="log-detail">
+    <h1><%= @log.title %></h1>
+    <div class="log-detail__langs">
+      <% @log.languages.each do |lang| %>
+        <p class="lang <%= lang.trim %>"><%= lang.name %></p>
+      <% end %>
+    </div>
+    <div class="log-updated-at">
+      <p>最終更新日：<%= l @log.updated_at, format: :default %></p>
+    </div>
+    <div class="log-detail__content errors">
+      <p class="log-detail__content-title">エラーの内容</p>
+      <%= @log.error %>
+    </div>
+    <div class="log-detail__content solutions">
+      <p class="log-detail__content-title">解決法</p>
+      <% if @log.solution.present? %>
+        <%= @log.solution %>
+      <% else %>
+        <p class="log-detail__content-nil">解決法はまだ登録されていません。</p>
+      <% end %>
+    </div>
   </div>
-  <table class="log-table" width="90%">
-    <tbody>
-      <tr>
-        <th class="log-show-th">エラー文</th>
-        <td><%= @log.error %></td>
-      </tr>
-      <tr>
-        <th class="log-show-th">解決法</th>
-        <td><%= @log.solution %></td>
-      </tr>
-      <tr>
-        <th class="log-show-th">開発言語</th>
-        <td><%= display_languages(@log.languages) %></td>
-      </tr>
-    </tbody>
-  </table>
 
   <div class="inner-bottom-btn-wrap">
     <% if user_signed_in? %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,12 +1,20 @@
 <section class="app-body-inner">
   <h1><%= @user.name %>のノート</h1>
-  <%= render "logs/table", logs: @logs, stock: "false" %>
+  <% if @logs.present? %>
+    <%= render "logs/table", logs: @logs, stock: "false" %>
+  <% else %>
+    <p class="no-content-message">ノートはまだありません。</p>
+  <% end %>
 </section>
 
 <% if user_signed_in? && (current_user.id == @user.id) %>
   <section class="app-body-inner">
     <h1>最近のストック</h1>
-    <%= render "logs/table", logs: @stocks, stock: "true" %>
+    <% if @stocks.present? %>
+      <%= render "logs/table", logs: @stocks, stock: "true" %>
+    <% else %>
+      <p class="no-content-message">ストックしたノートはまだありません。</p>
+    <% end %>
   </section>
 <% end %>
 


### PR DESCRIPTION
## PRの内容
- ログ詳細画面のスタイルを見直した
- ログがなかった場合の処理を追加した

Issue： #70 

## 具体的な内容
- エラー文や解決法のスペースを広げたほか、背景色を追加することによって視認性を高めた。

## 画面プレビュー
### 1. ログ詳細画面の新デザイン
<img width="864" alt="e5469afbd97091bd8d1ea04d5ef89997" src="https://user-images.githubusercontent.com/68951522/118113062-c4e18800-b420-11eb-818a-3f22b7955946.png">

### 2. 例外処理を実装したログ一覧
<img width="803" alt="9b9e401a33e936b020d02fe8cd348419" src="https://user-images.githubusercontent.com/68951522/118113185-ee021880-b420-11eb-9100-461427d552ca.png">

