### PR TITLE
ログ詳細ページをVue化した

### DIFF
--- a/app/controllers/api/v1/logs_controller.rb
+++ b/app/controllers/api/v1/logs_controller.rb
@@ -48,6 +48,23 @@ class Api::V1::LogsController < ApplicationController
     end
   end
 
+  def show
+    log = Log.find(params[:id])
+    languages = []
+    log.languages.each do |lang|
+      languages.push(name: lang.name)
+    end
+    log.user.picture ? picture = log.user.picture.url : picture = nil 
+    user = {id: log.user_id, name: log.user.name, picture: picture, introduce: log.user.introduce }
+    log = {title: log.title, error: log.error, solution: log.solution, release: log.release, updated_at: l(log.updated_at, format: :default)}
+    response = {
+      log: log,
+      languages: languages,
+      user: user,
+    }
+    render json: response
+  end
+
   def search
     logs = Log.search(params[:keyword]).page(params[:page]).per(params[:per])
     array = []

--- a/app/controllers/api/v1/stocks_controller.rb
+++ b/app/controllers/api/v1/stocks_controller.rb
@@ -8,9 +8,21 @@ class Api::V1::StocksController < ApplicationController
     counts = Stock.group(:log_id).order('count(log_id) desc').limit(5).count
     array = []
     logs.zip(counts) do |log, count|
-      array.push(id: log.id, title: log.title, count: count[1], user_id: log.user_id)
+      array.push(id: log.id, title: log.title.truncate(9), count: count[1], user_id: log.user_id)
     end
     render json: array
+  end
+
+  def check
+    user = User.find(params[:user_id])
+    log = Log.find(params[:log_id])
+    stocked = user.already_stocked?(log)
+    count = log.stocks.count
+    response = {
+      stocked: stocked,
+      count: count
+    }
+    render json: response
   end
 
 end

--- a/app/javascript/App.vue
+++ b/app/javascript/App.vue
@@ -1,9 +1,9 @@
 <template>
   <div id="app" class="app">
-    <Header @search="searchSignal" :user="user"></Header>
+    <Header @search="searchSignal" :currentUser="currentUser"></Header>
     <div class="app-body" id="app_body">
-      <LogsCreate v-if="user.auth == true"></LogsCreate>
-      <router-view :catchKeyword="keyword" :user="user"></router-view>
+      <LogsCreate v-if="currentUser.auth == true"></LogsCreate>
+      <router-view :catchKeyword="keyword" :currentUser="currentUser"></router-view>
     </div>
     <Footer></Footer>
   </div>
@@ -25,7 +25,7 @@ export default {
   },
   data(){
     return {
-      user: {
+      currentUser: {
         id: null,
         picture: null,
         auth: false,
@@ -37,7 +37,7 @@ export default {
     var self = this;
     axios
       .get('/api/v1/users/authentication.json')
-      .then(response => (self.user = response.data))
+      .then(response => (self.currentUser = response.data))
   },
   methods: {
     searchSignal: function(keyword){

--- a/app/javascript/App.vue
+++ b/app/javascript/App.vue
@@ -3,13 +3,14 @@
     <Header @search="searchSignal" :user="user"></Header>
     <div class="app-body" id="app_body">
       <LogsCreate v-if="user.auth == true"></LogsCreate>
-      <LogsIndex :catchKeyword="keyword" :user="user"></LogsIndex>
+      <router-view :catchKeyword="keyword" :user="user"></router-view>
     </div>
     <Footer></Footer>
   </div>
 </template>
 <script>
 import axios from 'axios'
+import VueRouter from 'vue-router'
 import LogsIndex from 'components/LogsIndex.vue'
 import LogsCreate from 'components/LogsCreate.vue'
 import Header from 'components/Header.vue'
@@ -44,6 +45,7 @@ export default {
     }
   }
 }
+
 </script>
 <style scoped>
 

--- a/app/javascript/components/Header.vue
+++ b/app/javascript/components/Header.vue
@@ -7,7 +7,7 @@
       <div class="header-center flex-3">
       </div>
       <div class="header-right flex-3">
-        <div v-if="this.user.auth == true">
+        <div v-if="this.currentUser.auth == true">
           <form @submit.prevent @keypress.prevent.enter.exact="searchLogs" class="search-form">
             <span class="fa-stack">
               <input v-model="keyword" placeholder="キーワードを入力" class="fa-lg fa-stack-2x">
@@ -16,12 +16,12 @@
             <input type="hidden" value="検索">
           </form>
           <div class="header-btn-wrap">
-            <a :href="'/users/'+ user.id +'/logs/new'" class="header-btn">
+            <a :href="'/users/'+ currentUser.id +'/logs/new'" class="header-btn">
               <i class="fas fa-pen fa-lg"></i>
             </a>
-            <a :href="'/users/'+ user.id" class="header-btn">
-              <template v-if="this.user.picture">
-                <img :src="this.user.picture" height="30px" width="30">
+            <a :href="'/users/'+ currentUser.id" class="header-btn">
+              <template v-if="this.currentUser.picture">
+                <img :src="this.currentUser.picture" height="30px" width="30">
               </template>
               <template v-else>
                 <img src="../../assets/images/human.png" height="30px" width="30px">
@@ -52,7 +52,13 @@ export default {
       keyword: "",
     }
   },
-  props: ["user"],
+  props: {
+    currentUser: {
+      id: null,
+      picture: null,
+      auth: false,
+    },
+  },
   mouted(){
 
   },

--- a/app/javascript/components/Header.vue
+++ b/app/javascript/components/Header.vue
@@ -75,6 +75,10 @@ export default {
 
 }
 </script>
-<style scoped>
-
+<style lang="scss" scoped>
+.header-left {
+  h1:hover{
+    cursor: pointer;
+  }
+}
 </style>

--- a/app/javascript/components/Header.vue
+++ b/app/javascript/components/Header.vue
@@ -2,7 +2,7 @@
   <div class="header-area">
     <div class="header-container">
       <div class="header-left flex-3">
-        <h1><a href="/">Error Note</a></h1>
+        <h1 @click="goHome">Error Note</h1>
       </div>
       <div class="header-center flex-3">
       </div>
@@ -65,6 +65,11 @@ export default {
   methods: {
     searchLogs: function(){
       this.$emit('search', this.keyword)
+    },
+    goHome: function(){
+      this.$router.push({
+        name: 'logs-index'
+      })
     }
   }
 

--- a/app/javascript/components/LogsIndex.vue
+++ b/app/javascript/components/LogsIndex.vue
@@ -23,7 +23,7 @@
       <v-list three-line>
         <article v-for="(item) in logs" :key="item.id" class="log-block" :items-per-page="itemPerPage">
           <div class="log-block__upper">
-            <h2><a @click="showMoreInfomations(item.user_id, item.id)">{{item.title}}</a></h2>
+            <h2 @click="showMoreInfomations(item.user_id, item.id)">{{item.title}}</h2>
           </div>
           <div class="log-block__lower">
             <div class="log-block__lower-languages">

--- a/app/javascript/components/LogsIndex.vue
+++ b/app/javascript/components/LogsIndex.vue
@@ -77,7 +77,7 @@
         </iframe>
       </div>
       <div class="nav-bar__lang-rank" id="nav_bar_lang_rank">
-        <userRank></userRank>
+        <UserRank></UserRank>
       </div>
     </section>
   </div>
@@ -86,11 +86,11 @@
 <script>
 import axios from 'axios';
 import Vuetify from 'vuetify';
-import userRank from 'components/UserRank.vue';
+import UserRank from 'components/UserRank.vue';
 
 export default {
   components: {
-    'userRank': userRank,
+    'UserRank': UserRank,
   },
   data(){
     return{

--- a/app/javascript/components/LogsIndex.vue
+++ b/app/javascript/components/LogsIndex.vue
@@ -201,7 +201,8 @@ export default {
   }
 }
 </script>
-<style scoped>
+<style lang="scss" scoped>
+.log-block__upper h2,
 .nav-link:hover {
   cursor: pointer;
 }

--- a/app/javascript/components/LogsIndex.vue
+++ b/app/javascript/components/LogsIndex.vue
@@ -115,7 +115,7 @@ export default {
     }
   },
   props: {
-    user: {
+    currentUser: {
       id: null,
       picture: null,
       auth: false,
@@ -173,7 +173,7 @@ export default {
         this.pageTitle = "検索結果"
       }
       axios
-        .get(`/api/v1/logs/search.json?keyword=${this.keyword}&page=${this.currentPage}&per=${this.itemPerPage}&user_id=${this.user.id}`)
+        .get(`/api/v1/logs/search.json?keyword=${this.keyword}&page=${this.currentPage}&per=${this.itemPerPage}&user_id=${this.currentUser.id}`)
         .then(response => (
           this.logs = response.data.logs,
           this.totalPages = response.data.total_page 

--- a/app/javascript/components/LogsIndex.vue
+++ b/app/javascript/components/LogsIndex.vue
@@ -10,7 +10,7 @@
           <i class="fas fa-fire-alt"></i>
           <a class="nav-link" @click="this.getMostStockedLogs">話題のノート</a>
         </div>
-        <template v-if="this.user.auth == true">
+        <template v-if="this.currentUser.auth == true">
           <div class="navigation__link-wrap">
             <i class="fas fa-cubes"></i>
             <a class="nav-link" @click="this.getLatestStocks">最近ストックしたノート</a>

--- a/app/javascript/components/LogsIndex.vue
+++ b/app/javascript/components/LogsIndex.vue
@@ -23,7 +23,7 @@
       <v-list three-line>
         <article v-for="(item) in logs" :key="item.id" class="log-block" :items-per-page="itemPerPage">
           <div class="log-block__upper">
-            <h2><a :href="'/users/'+item.user_id+'/logs/'+item.id">{{item.title}}</a></h2>
+            <h2><a @click="showMoreInfomations(item.user_id, item.id)">{{item.title}}</a></h2>
           </div>
           <div class="log-block__lower">
             <div class="log-block__lower-languages">
@@ -182,6 +182,15 @@ export default {
     trimName: function(langName){
       var name = langName.toLowerCase().replace(/\s+/g, '').replace('#', 's').replace('.', 'd');
       return name;
+    },
+    showMoreInfomations: function(user_id, log_id){
+      this.$router.push({
+        name: 'log-show',
+        params: {
+          user_id: user_id,
+          log_id: log_id, 
+        }
+      })
     }
   },
   watch: {

--- a/app/javascript/components/LogsShow.vue
+++ b/app/javascript/components/LogsShow.vue
@@ -1,0 +1,13 @@
+<template>
+  
+</template>
+
+<script>
+export default {
+  
+}
+</script>
+
+<style lang="scss" scoped>
+
+</style>

--- a/app/javascript/components/LogsShow.vue
+++ b/app/javascript/components/LogsShow.vue
@@ -1,10 +1,121 @@
 <template>
-  
+  <div id="log-details">
+    <section class="app-body-inner">
+      <div class="log-detail">
+        <h1>{{ log.title }}</h1>
+        <div class="log-detail__langs">
+          <template v-for="language in languages">
+            <p class="lang" :class="trimName(language.name)" :key="language.name">{{ language.name }}</p>
+          </template>
+        </div>
+        <div class="log-updated-at">
+          <p>最終更新日：{{ log.updated_at }}</p>
+        </div>
+        <div class="log-detail__content errors">
+          <p class="log-detail__content-title">エラーの内容</p>
+          {{ log.error }}
+        </div>
+        <div class="log-detail__content solutions">
+          <p class="log-detail__content-title">解決法</p>
+            <p v-if="log.solution">{{log.solution}}</p>
+            <p v-else class="log-detail__content-nil">解決法はまだ登録されていません。</p>
+        </div>
+      </div>
+      <div class="inner-bottom-btn-wrap">
+        <template v-if="currentUser.auth == true">
+          <template v-if="currentUser.id == user.id">
+            <a class="btn-default">ログを編集する</a>
+            <a class="btn-danger">ログを削除する</a>
+          </template>
+          <template v-else>
+            <template v-if="alreadyStocked == true">
+              <button class="btn-filled"> <!-- ここにストックアクションを追加 -->
+                <p>ストックを取り消す <span class="stock-count__number">{{ stockedCount }}</span></p>
+              </button>
+            </template>
+            <template v-else>
+              <button class="btn-default"> <!-- ここにストックアクションを追加 -->
+                <p>ストックする <span class="stock-count__number">{{ stockedCount }}</span></p>
+              </button>
+            </template>
+          </template>
+        </template>
+        <template v-else>
+          <button class="btn-default"> <!-- ここにストックアクションを追加 -->
+            <p>ストックする <span class="stock-count__number">{{ stockedCount }}</span></p>
+          </button>
+        </template>
+      </div>
+    </section>
+    <UsersProfile :user="user" :currentUser="currentUser" use_case="log"></UsersProfile>
+  </div>
 </template>
 
 <script>
+import axios from 'axios';
+import UsersProfile from './UsersProfile';
+
 export default {
-  
+  components: {
+    'UsersProfile': UsersProfile,
+  },
+  data(){
+    return {
+      log: {
+        id: 0,
+        user_id: 0,
+        title: "",
+        error: "",
+        solution: "",
+        release: false,
+      },
+      user: {
+        id: 0,
+        name: "",
+        picture: "",
+        introduce: "",
+      },
+      languages: [
+        {name: ""},
+      ],
+      stockedCount: 0,
+      alreadyStocked: false,
+    }
+  },
+  props: {
+    currentUser: {
+      id: null,
+      picture: null,
+      auth: false,
+    },
+  },
+  mounted(){
+    this.getLogDetail();
+    this.getStockData();
+  },
+  methods: {
+    getLogDetail: async function(){
+      await axios
+        .get(`/api/v1/logs/show.json?user_id=${this.$route.params['user_id']}&id=${this.$route.params['log_id']}`)
+        .then(response => (
+          this.log = response.data.log,
+          this.user = response.data.user,
+          this.languages = response.data.languages
+        ))
+    },
+    trimName: function(langName){
+      var name = langName.toLowerCase().replace(/\s+/g, '').replace('#', 's').replace('.', 'd');
+      return name;
+    },
+    getStockData: async function(current_user_id, log_id){
+      await axios
+        .get(`/api/v1/stocks/check.json?user_id=${this.currentUser.id}&log_id=${this.$route.params['log_id']}`)
+        .then(response => (
+          this.alreadyStocked = response.data.stocked,
+          this.stockedCount = response.data.count
+        ))
+    }
+  }
 }
 </script>
 

--- a/app/javascript/components/UsersProfile.vue
+++ b/app/javascript/components/UsersProfile.vue
@@ -1,0 +1,63 @@
+<template>
+  <div class="app-bottom-inner">
+    <div class="bottom-profile__upper">
+      <div class="profile-img__container">
+        <img v-if="user.picture != null" :src="user.picture">
+        <img v-else src="../../assets/images/human.png">
+      </div>
+      <div class="profile-introduce__container">
+        <div class="profile-introduce__name">
+          <h2>{{ user.name }}</h2>
+        </div>
+        <div class="profile-introduce__word">
+          {{ user.introduce }}
+        </div>
+      </div>
+    </div>
+    <div class="bottom-profile__lower">
+      <div class="profile-btn__container">
+        <template v-if="use_case == 'log'">
+          <a v-if="(currentUser.auth == true) && (currentUser.id != user.id)" class="btn-filled">フォローする</a>
+          <a class="btn-default">プロフィールへ</a>
+        </template>
+        <template v-else>
+          <template v-if="(currentUser.auth == true) && (currentUser.id == user.id)">
+            <a class="btn-filled">プロフィール編集</a>
+            <a class="btn-default">ログアウト</a>
+          </template>
+          <template v-else-if="(currentUser.auth == true) && (currentUser.id != user.id)">
+            <a class="btn-filled">フォローする</a>
+          </template>
+        </template>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+export default {
+  data(){
+    return {
+      
+    }
+  },
+  props: {
+    user: {
+      id: 0,
+      name: "",
+      picture: "",
+      introduce: "",
+    },
+    currentUser: {
+      id: null,
+      picture: null,
+      auth: false,
+    },
+    use_case: "",
+  }
+}
+</script>
+
+<style lang="scss">
+
+</style>

--- a/app/javascript/packs/main.js
+++ b/app/javascript/packs/main.js
@@ -1,11 +1,11 @@
-import Vue from 'vue'
-import App from '../App.vue'
-import Vuetify from 'vuetify'
+import Vue from 'vue';
+import App from '../App.vue';
+import Vuetify from 'vuetify';
+import router from './router';
 
 Vue.use(Vuetify);
 
 document.addEventListener('turbolinks:load', () => {
-  // const exclusionPath = "users$"
   const insertTarget = document.getElementById('body')
   const alreadyInsert = document.getElementById('app')
   if(alreadyInsert) {
@@ -16,6 +16,7 @@ document.addEventListener('turbolinks:load', () => {
   if(document.URL.match("/users/")) return false;
   if(insertTarget) {
     const usr = new Vue({
+      router,
       vuetify: new Vuetify(),
       render: h => h(App)
     }).$mount()

--- a/app/javascript/packs/router.js
+++ b/app/javascript/packs/router.js
@@ -1,0 +1,22 @@
+import Vue from 'vue';
+import Router from 'vue-router';
+import LogsIndex from '../components/LogsIndex.vue';
+import LogsShow from '../components/LogsShow.vue';
+
+Vue.use(Router);
+
+export default new Router({
+  mode: "history",
+  routes: [
+    { 
+      path: '/', 
+      component: LogsIndex,
+      name: 'logs-index',
+    },
+    {
+      path: '/users/:user_id/logs/:log_id',
+      component: LogsShow,
+      name: 'log-show',
+    }
+  ]
+});

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -15,6 +15,7 @@
 
   <script src="https://cdn.jsdelivr.net/npm/vue@2.x/dist/vue.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/vuetify@2.x/dist/vuetify.js"></script>
+  <script src="https://unpkg.com/vue-router/dist/vue-router.js"></script>
   <body id="body">
     <%= yield %>
   </body>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -28,6 +28,7 @@ Rails.application.routes.draw do
           get 'latest_stocks'
           get 'most_stocked_logs'
           post 'create'
+          get 'show'
           get 'search'
         end
       end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -41,6 +41,7 @@ Rails.application.routes.draw do
       resources :stocks, only: [] do
         collection do
           get 'rank'
+          get 'check'
         end
       end
       resources :log_languages, only: [] do

--- a/package-lock.json
+++ b/package-lock.json
@@ -9212,6 +9212,11 @@
         "vue-style-loader": "^4.1.0"
       }
     },
+    "vue-router": {
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/vue-router/-/vue-router-3.5.1.tgz",
+      "integrity": "sha512-RRQNLT8Mzr8z7eL4p7BtKvRaTSGdCbTy2+Mm5HTJvLGYSSeG9gDzNasJPP/yOYKLy+/cLG/ftrqq5fvkFwBJEw=="
+    },
     "vue-style-loader": {
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/vue-style-loader/-/vue-style-loader-4.1.3.tgz",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "turbolinks": "^5.2.0",
     "vue": "^2.6.12",
     "vue-loader": "^15.9.6",
+    "vue-router": "^3.5.1",
     "vue-template-compiler": "^2.6.12",
     "vue-turbolinks": "^2.2.2",
     "vuejs-paginate": "^2.1.0",


### PR DESCRIPTION
## PRの内容
- ユーザビリティ向上のため、ログ詳細ページをVue化した
- 詳細ページのVueにより、それ以降のパス変更なしに削除・編集が行えるようになった（今後実装予定）

Issue： #86 

(画面自体に変更はないためプレビューはなし)

## PRについての留意点
- ログの編集・削除は現状のビュー（Vue ）から行うことができない
- usersが含まれるパスでは描画しない設定となっているため、リロードすると従来のビューを表示する
- ユーザーのプロフィールへ遷移するボタンは押下しても遷移できない
