### PR TITLE
ログ削除機能のVue化

### DIFF
--- a/app/controllers/api/v1/logs_controller.rb
+++ b/app/controllers/api/v1/logs_controller.rb
@@ -81,6 +81,16 @@ class Api::V1::LogsController < ApplicationController
     end
   end
 
+  def destroy
+    log = Log.find(params[:id])
+    user_id = log.user_id
+    if log.destroy
+      render json: user_id
+    else
+      render json: log.errors, status: :unprocessable_entity
+    end
+  end
+
   def search
     logs = Log.search(params[:keyword]).page(params[:page]).per(params[:per])
     array = []

--- a/app/javascript/components/LogsDestroy.vue
+++ b/app/javascript/components/LogsDestroy.vue
@@ -1,0 +1,61 @@
+<template>
+  <div id="log_modal">
+    <div class="log-modal__back" @click.self="$emit('cancel')">
+      <div class="log-modal__container-destroy">
+        <h2>このノートを削除しますか？</h2>
+        <p class="log-modal__sub-title">「{{ title }}」</p>
+        <div class="inner-bottom-btn-wrap">
+          <input @click="$emit('cancel')" type="submit" value="キャンセル" class="btn-default">
+          <input @click="$emit('submit')" type="submit" value="削除する" class="btn-danger">
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+export default {
+  data(){
+    return {
+
+    }
+  },
+  props: {
+    title: {type: String}
+  }
+}
+</script>
+
+<style lang="scss" scoped>
+.inner-bottom-btn-wrap {
+  margin-top: 20px;
+  text-align: center;
+}
+.log-modal {
+  &__back {
+    background-color: rgba(0,0,0, 0.4);
+    width: 100%;
+    height: 100%;
+    position: fixed;
+    top: 0;
+    left: 0;
+    z-index: 5;
+  }
+  &__container-destroy {
+    background-color: white;
+    padding: 32px;
+    max-width: 600px;
+    max-height: 60%;
+    margin: 70px auto 30px;
+    z-index: 6;
+    h2 {
+      text-align: center;
+    }
+  }
+  &__sub-title {
+    color: gray;
+    margin-top: 50px;
+    text-align: center;
+  }
+}
+</style>

--- a/app/javascript/components/LogsShow.vue
+++ b/app/javascript/components/LogsShow.vue
@@ -10,6 +10,12 @@
       @submit="updateNote"
       @change="changeCheckedLanguages"
     />
+    <LogsDestroy
+      v-if="(currentUser.auth == true) && (currentUser.id == user.id) && (confirmModal == true)" 
+      :title="log.title"
+      @submit="destroyNote"
+      @cancel="toggleConfirmModal"
+    />
     <section class="app-body-inner">
       <div class="log-detail">
         <h1>{{ log.title }}</h1>
@@ -35,7 +41,7 @@
         <template v-if="currentUser.auth == true">
           <template v-if="currentUser.id == user.id">
             <a @click="toggleModal" class="btn-default">ログを編集する</a>
-            <a class="btn-danger">ログを削除する</a>
+            <a @click="toggleConfirmModal" class="btn-danger">ログを削除する</a>
           </template>
           <template v-else>
             <template v-if="alreadyStocked == true">
@@ -65,6 +71,7 @@
 import axios from 'axios';
 import UsersProfile from './UsersProfile';
 import LogsUpdate from './LogsUpdate';
+import LogsDestroy from './LogsDestroy';
 
 const token = document.getElementsByName("csrf-token")[0].getAttribute("content");
 axios.defaults.headers.common["X-CSRF-Token"] = token;
@@ -73,6 +80,7 @@ export default {
   components: {
     'UsersProfile': UsersProfile,
     'LogsUpdate': LogsUpdate,
+    'LogsDestroy': LogsDestroy,
   },
   data(){
     return {
@@ -100,6 +108,7 @@ export default {
       checkedLanguages: [],
       errors: [],
       modal: false,
+      confirmModal: false,
       stockedCount: 0,
       newCheckedLanguages: [],
       newLog: [],
@@ -142,6 +151,9 @@ export default {
     toggleModal: function(){
       this.modal == true ? this.modal = false : this.modal = true;
     },
+    toggleConfirmModal: function(){
+      this.confirmModal == true ? this.confirmModal = false : this.confirmModal = true;
+    },
     getLanguageIds: function(languages){
       for(var language in languages) {
         this.checkedLanguages.push(languages[language].id)
@@ -182,7 +194,18 @@ export default {
       await this.beforUpdate();
       await this.updateLog(args[0], this.newCheckedLanguages[0]);
       await this.afterUpdate();
-    }
+    },
+    destroyNote: function(){
+      axios
+        .delete(`/api/v1/logs/destroy.json?id=${this.log.id}`)
+        .then(response => {
+          console.log(response.data)
+          location.href=`/users/${response.data}`;
+        })
+        .catch(err => {
+          console.log('error:', err)
+        })
+    },
   }
 }
 </script>

--- a/app/javascript/components/LogsUpdate.vue
+++ b/app/javascript/components/LogsUpdate.vue
@@ -105,7 +105,7 @@ export default {
   },
 }
 </script>
-<style scoped>
+<style lang="scss" scoped>
 .inner-bottom-btn-wrap {
   margin-top: 20px;
   text-align: center;

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -31,6 +31,7 @@ Rails.application.routes.draw do
           get 'show'
           put 'update'
           get 'search'
+          delete 'destroy'
         end
       end
       resources :languages, only: [] do


### PR DESCRIPTION
## PRの内容
- ユーザビリティ向上を目的に、ログ削除機能をVue化した

## 機能の詳細
- 「削除する」ボタンを押下するとモーダルウィンドウを表示し、削除またはキャンセルを行うことができる。
- 削除後はマイページに遷移する。
- キャンセルあるいはモーダル枠外を押下するとモーダルウィンドウを閉じる。

Issue： #94 