### PR TITLE
トップページ以外からでも検索を行えるようにした

### DIFF
--- a/app/assets/stylesheets/shared.scss
+++ b/app/assets/stylesheets/shared.scss
@@ -453,11 +453,12 @@ form {
   background-color: $site-danger-bg-color;
   border: 5px solid $site-danger-border-color;
   border-radius: 20px;
+  padding: 10px;
   margin: 0 auto;
   width: 80%;
   h2 {
     font-size: 1rem;
-    padding: 10px;
+    margin-bottom: 5px;
   }
   li {
     list-style: none;

--- a/app/javascript/components/Header.vue
+++ b/app/javascript/components/Header.vue
@@ -64,7 +64,14 @@ export default {
   },
   methods: {
     searchLogs: function(){
-      this.$emit('search', this.keyword)
+      if(location.pathname != "/"){
+        this.goHome()
+        setTimeout(()=>{
+          this.$emit('search', this.keyword)
+        }, 250)
+      } else {
+        this.$emit('search', this.keyword)
+      }
     },
     goHome: function(){
       if(location.pathname != "/"){

--- a/app/javascript/components/LogsIndex.vue
+++ b/app/javascript/components/LogsIndex.vue
@@ -90,6 +90,12 @@ export default {
   mounted(){
     this.getLatestLogs();
   },
+  watch: {
+    catchKeyword: function(){
+      this.keyword = this.$props.catchKeyword;
+      this.getSearchLogs();
+    }
+  },
   methods: {
     getLatestLogs: function(){
       if (this.currentLogs != this.getLatestLogs){
@@ -123,7 +129,7 @@ export default {
         this.currentPage = 1;
         this.currentLogs = this.getLatestStocks;
         this.pageTitle = "最近ストックしたノート"
-      }  
+      }
       axios
         .get(`/api/v1/logs/latest_stocks_index.json?page=${this.currentPage}&per=${this.itemPerPage}`)
         .then(response => (
@@ -170,12 +176,6 @@ export default {
       this.currentLogs();
     },
   },
-  watch: {
-    catchKeyword: function(){
-      this.keyword = this.$props.catchKeyword;
-      this.getSearchLogs();
-    }
-  }
 }
 </script>
 <style lang="scss" scoped>


### PR DESCRIPTION
## PRの内容
- トップページ以外から検索をしようとすると、Enterを押下しても何も起きない問題を解消するため、検索処理の修正を行なった。
- トップページ以外から検索した場合は、トップページに遷移したのちにキーワード情報を送信し、検索を行うよう処理を変更した。
- トップページから検索を行なった場合の処理は従来通り。

Issue : #105 