### PR TITLE
モーダルウィンドウ表示時に背景をスクロールできないようにした

### DIFF
--- a/app/assets/stylesheets/shared.scss
+++ b/app/assets/stylesheets/shared.scss
@@ -26,6 +26,10 @@ form {
   margin-right: 5px;
 }
 
+.scroll-lock {
+  overflow: hidden;
+}
+
 @mixin inner-base {
   background-color: white;
   max-width: 730px;

--- a/app/javascript/App.vue
+++ b/app/javascript/App.vue
@@ -11,7 +11,10 @@
         :logSignal="logSignal"
         @closeLogSignal="closeLog"
       />
-      <router-view :catchKeyword="keyword" :currentUser="currentUser"></router-view>
+      <router-view
+        :catchKeyword="keyword"
+        :currentUser="currentUser"
+      />
     </div>
     <Footer/>
   </div>

--- a/app/javascript/components/LogsCreate.vue
+++ b/app/javascript/components/LogsCreate.vue
@@ -94,7 +94,14 @@ export default {
   },
   methods: {
     toggleModal: function(){
-      this.modal == true ? this.modal = false : this.modal = true;
+      const targetSelector = document.getElementsByTagName('html')[0];
+      if(this.modal){
+        this.modal = false;
+        targetSelector.classList.remove("scroll-lock");
+      } else {
+        this.modal = true;
+        targetSelector.classList.add("scroll-lock");
+      }
     },
     beforCreate: function(e){
       this.errors = [];

--- a/app/javascript/components/LogsShow.vue
+++ b/app/javascript/components/LogsShow.vue
@@ -149,10 +149,24 @@ export default {
         ))
     },
     toggleModal: function(){
-      this.modal == true ? this.modal = false : this.modal = true;
+      const targetSelector = document.getElementsByTagName('html')[0];
+      if(this.modal){
+        this.modal = false;
+        targetSelector.classList.remove("scroll-lock");
+      } else {
+        this.modal = true;
+        targetSelector.classList.add("scroll-lock");
+      }
     },
     toggleConfirmModal: function(){
-      this.confirmModal == true ? this.confirmModal = false : this.confirmModal = true;
+      const targetSelector = document.getElementsByTagName('html')[0];
+      if(this.confirmModal){
+        this.confirmModal = false;
+        targetSelector.classList.remove("scroll-lock");
+      } else {
+        this.confirmModal = true;
+        targetSelector.classList.add("scroll-lock");
+      }
     },
     getLanguageIds: function(languages){
       for(var language in languages) {


### PR DESCRIPTION
## PRの内容
- モーダルウィンドウ表示時に背景がスクロールできてしまう問題を解消するため、モーダルウィンドウ切り替えの処理を改善した。
- 上記により、モーダルウィンドウ表示時は背景部分をスクロールできないようになった。（iOSを除く）

Issue : #104 