### PR TITLE
ログ出力のローテート設定

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -69,6 +69,8 @@ Rails.application.configure do
   # Prepend all log lines with the following tags.
   config.log_tags = [:request_id]
 
+  config.logger = Logger.new("log/production.log", 5, 10 * 1024 * 1024)
+
   # Use a different cache store in production.
   # config.cache_store = :mem_cache_store
 


### PR DESCRIPTION
## PRの内容
- ログファイルの可読性向上、ストレージ圧迫防止のため、ログのローテート設定を行った。
- 10MBを超えるごとにローテートし、5ファイルを超えたものは削除するように設定した。

Issue : #136 

## 動作確認方法
1. `git fetch origin pull/138/head:feature-log-rotate`
1. `git checkout feature-log-rotate`
1. `bundle install`
1. `rails s`

## reviewerへの参考情報等
特になし